### PR TITLE
feat(telemetry): anonymous PostHog usage telemetry with opt-out

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = extension-ci-tools
 	url = https://github.com/duckdb/extension-ci-tools
 	branch = v1.5.3
+[submodule "posthog-telemetry"]
+	path = posthog-telemetry
+	url = https://github.com/DataZooDE/posthog-telemetry.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,18 @@ include_directories(src/include)
 # the DUCKDB_SOURCES module `http_client_duckdb.cpp` uses it.
 include_directories(./duckdb/third_party/httplib)
 
+# Anonymous usage telemetry (shared library with ../erpl and ../erpl-web).
+# Native only -- the lib uses `duckdb_httplib_openssl::SSLClient` which is
+# not portable to wasm. The matching `PostHogTelemetry::Instance().*` calls
+# in src/ are guarded with `#ifndef EMSCRIPTEN`. Opt-out is documented in
+# README.md ("Telemetry") and exposed as the `quack_oauth_telemetry_enabled`
+# setting + the `DATAZOO_DISABLE_TELEMETRY` env var.
+# The submodule's own CMakeLists.txt finds + links OpenSSL itself.
+if(NOT EMSCRIPTEN)
+    include_directories(posthog-telemetry/include)
+    add_subdirectory(posthog-telemetry)
+endif()
+
 # Pure-logic sources (no DuckDB includes) -- compiled into BOTH the extension
 # and the Catch2 unit-test binary. See docs/IMPLEMENTATION.md section 2.3.
 set(PURE_SOURCES
@@ -100,8 +112,13 @@ build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 target_compile_features(${EXTENSION_NAME} PRIVATE cxx_std_17)
 target_compile_features(${LOADABLE_EXTENSION_NAME} PRIVATE cxx_std_17)
 
-target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
-target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
+if(NOT EMSCRIPTEN)
+  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry)
+  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry)
+else()
+  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
+  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
+endif()
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/README.md
+++ b/README.md
@@ -647,6 +647,34 @@ SELECT * FROM quack_oauth_diagnose();
 The `token_hash` column is always the first 8 hex of `sha256(token)` —
 **never** the raw bearer.
 
+## Telemetry
+
+The extension sends anonymous usage events to a DataZoo-owned PostHog
+project so we can see which OAuth flows and provider presets get
+exercised in practice. Two event types ship: one `extension_load`
+when DuckDB first loads `quack_oauth`, and one `function_execution`
+each time a user-facing function (`quack_oauth_login`,
+`quack_oauth_acquire`, `quack_oauth_diagnose`, …) is invoked. Each
+event carries the extension name + version, DuckDB version, host
+platform, and a stable anonymous identifier derived from the
+machine's first physical MAC address. **No tokens, no claims, no
+SQL, no SECRET fields, no IdP URLs are sent.**
+
+This is on by default and can be disabled two ways — either is
+enough:
+
+```sql
+-- per-database, runtime
+SET quack_oauth_telemetry_enabled = false;
+```
+
+```bash
+# machine-wide, env var (also honoured by ../erpl and ../erpl-web)
+export DATAZOO_DISABLE_TELEMETRY=1
+```
+
+Full policy: <https://erpl.io/telemetry>.
+
 ## Features
 
 - **Four validation modes** (`jwks` / `introspect` / `tokeninfo` /

--- a/src/acquire_function.cpp
+++ b/src/acquire_function.cpp
@@ -20,6 +20,7 @@
 #include "platform_time.hpp"
 #include "refresh_function.hpp"
 #include "secret_accessor.hpp"
+#include "telemetry.hpp"
 
 namespace duckdb {
 
@@ -129,6 +130,7 @@ static string DoAcquire(ClientContext &context, const string &secret_name) {
 }
 
 static void AcquireScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_acquire");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto tok = DoAcquire(context, secret_name_str.GetString());

--- a/src/check_authorization_function.cpp
+++ b/src/check_authorization_function.cpp
@@ -27,6 +27,10 @@
 #include "sql_inspect.hpp"
 #include "tracing.hpp"
 
+#ifndef EMSCRIPTEN
+#include "telemetry.hpp"
+#endif
+
 namespace duckdb {
 
 // Resolve the policy_table from the active TYPE=quack_oauth_server SECRET.
@@ -57,6 +61,9 @@ static int64_t LookupClockSkew(ClientContext &context) {
 }
 
 static void CheckAuthorizationScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+#ifndef EMSCRIPTEN
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_authorization");
+#endif
 	auto &context = state.GetContext();
 	auto &shared_state = GetQuackOauthState();
 

--- a/src/check_token_function.cpp
+++ b/src/check_token_function.cpp
@@ -28,6 +28,7 @@
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
 #include "secure_scrub.hpp"
+#include "telemetry.hpp"
 #include "tracing.hpp"
 #include "validator.hpp"
 
@@ -394,6 +395,7 @@ static void RunValidationLoop(Vector &tokens, idx_t count, Vector &result, Clien
 // cache the extracted Principal in QuackOauthState::session_principals so
 // the companion authz scalar can look it up.
 static void ValidateChunk(Vector &tokens, idx_t count, Vector &result, ClientContext &context, Vector *session_ids) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_token");
 	const auto cfg = LoadServerConfig(context);
 
 	quack_oauth::VerifyOptions opts;

--- a/src/device_login_function.cpp
+++ b/src/device_login_function.cpp
@@ -20,6 +20,7 @@
 #include "platform_time.hpp"
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
+#include "telemetry.hpp"
 
 namespace duckdb {
 
@@ -109,6 +110,7 @@ string DoDeviceLoginImpl(ClientContext &context, const string &secret_name) {
 }
 
 static void DeviceLoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_device_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoDeviceLoginImpl(context, secret_name_str.GetString());

--- a/src/diagnose.cpp
+++ b/src/diagnose.cpp
@@ -17,6 +17,10 @@
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
 
+#ifndef EMSCRIPTEN
+#include "telemetry.hpp"
+#endif
+
 namespace duckdb {
 
 struct DiagnoseRow {
@@ -50,6 +54,9 @@ static string ReadSetting(ClientContext &context, const string &key) {
 
 static unique_ptr<FunctionData> DiagnoseBind(ClientContext &context, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
+#ifndef EMSCRIPTEN
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_diagnose");
+#endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	names = {"component", "status", "detail"};
 
@@ -207,6 +214,9 @@ struct AuditLogGlobalState : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> AuditLogBind(ClientContext &, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
+#ifndef EMSCRIPTEN
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_audit_log");
+#endif
 	return_types = {LogicalType::BIGINT,  LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	names = {"timestamp_unix_s", "event_type", "subject", "issuer", "kid", "token_hash", "action", "reason"};
@@ -275,6 +285,9 @@ struct CurrentPrincipalGlobalState : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> CurrentPrincipalBind(ClientContext &, TableFunctionBindInput &,
                                                      vector<LogicalType> &return_types, vector<string> &names) {
+#ifndef EMSCRIPTEN
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_current_principal");
+#endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::LIST(LogicalType::VARCHAR), LogicalType::BIGINT};
 	names = {"session_id", "subject", "issuer", "scopes", "exp"};

--- a/src/login_function.cpp
+++ b/src/login_function.cpp
@@ -18,6 +18,7 @@
 #include "platform_time.hpp"
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
+#include "telemetry.hpp"
 #include "token_endpoint.hpp"
 
 namespace duckdb {
@@ -63,6 +64,7 @@ string DoLogin(ClientContext &context, const string &secret_name) {
 }
 
 static void LoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoLogin(context, secret_name_str.GetString());

--- a/src/logout_function.cpp
+++ b/src/logout_function.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "secret_accessor.hpp"
+#include "telemetry.hpp"
 
 namespace duckdb {
 
@@ -39,6 +40,7 @@ static bool DoLogout(ClientContext &context, const string &secret_name) {
 }
 
 static void LogoutScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_logout");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		return DoLogout(context, secret_name_str.GetString());

--- a/src/quack_oauth_extension.cpp
+++ b/src/quack_oauth_extension.cpp
@@ -15,6 +15,7 @@
 #include "login_function.hpp"
 #include "logout_function.hpp"
 #include "refresh_function.hpp"
+#include "telemetry.hpp"
 #endif
 
 #include "duckdb/main/config.hpp"
@@ -25,6 +26,14 @@ namespace duckdb {
 
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+#ifndef EMSCRIPTEN
+	// Anonymous usage telemetry. Same key, same library, same opt-out paths
+	// as ../erpl and ../erpl-web. SetAPIKey must precede CaptureExtensionLoad;
+	// settings registration follows so that user-supplied
+	// `quack_oauth_telemetry_key` overrides the default via OnTelemetryKey.
+	PostHogTelemetry::Instance().SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
+	PostHogTelemetry::Instance().CaptureExtensionLoad("quack_oauth", QuackOauthExtension().Version());
+#endif
 	RegisterQuackOauthSettings(config);
 	RegisterQuackOauthSecrets(loader);
 	RegisterQuackOauthDiagnose(loader);

--- a/src/refresh_function.cpp
+++ b/src/refresh_function.cpp
@@ -18,6 +18,7 @@
 #include "platform_time.hpp"
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
+#include "telemetry.hpp"
 #include "token_endpoint.hpp"
 
 namespace duckdb {
@@ -65,6 +66,7 @@ string DoRefresh(ClientContext &context, const string &secret_name) {
 }
 
 static void RefreshScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_refresh");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoRefresh(context, secret_name_str.GetString());

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -4,7 +4,25 @@
 
 #include "env_overrides.hpp"
 
+#ifndef EMSCRIPTEN
+#include "telemetry.hpp"
+#endif
+
 namespace duckdb {
+
+#ifndef EMSCRIPTEN
+// Telemetry opt-out + key override callbacks. Forward to the
+// PostHogTelemetry singleton so a runtime `SET quack_oauth_telemetry_enabled
+// = false` (or a redirected key) takes effect immediately. Pattern copied
+// from ../erpl-web/src/erpl_web_extension.cpp:88-98.
+static void OnTelemetryEnabled(ClientContext &, SetScope, Value &parameter) {
+	PostHogTelemetry::Instance().SetEnabled(parameter.GetValue<bool>());
+}
+
+static void OnTelemetryKey(ClientContext &, SetScope, Value &parameter) {
+	PostHogTelemetry::Instance().SetAPIKey(parameter.GetValue<std::string>());
+}
+#endif
 
 // R-S-11(c) helpers: resolve each setting's default from the matching
 // `QUACK_OAUTH_<UPPER>` environment variable when present. SET in SQL
@@ -89,6 +107,23 @@ void RegisterQuackOauthSettings(DBConfig &config) {
 	config.AddExtensionOption("quack_oauth_server_secret_name",
 	                          "Name of the quack_oauth_server SECRET that check_token reads.", LogicalType::VARCHAR,
 	                          EnvStringDefault("QUACK_OAUTH_SERVER_SECRET_NAME", ""), nullptr, SetScope::GLOBAL);
+
+#ifndef EMSCRIPTEN
+	// Anonymous usage telemetry (shared with ../erpl and ../erpl-web). Default
+	// on. Two opt-out paths -- this setting AND the `DATAZOO_DISABLE_TELEMETRY`
+	// env var checked inside posthog-telemetry's PostHogProcess(). See README
+	// "Telemetry" section.
+	config.AddExtensionOption(
+	    "quack_oauth_telemetry_enabled",
+	    "Enable anonymous usage telemetry, see https://erpl.io/telemetry for details.", LogicalType::BOOLEAN,
+	    EnvBoolDefault("QUACK_OAUTH_TELEMETRY_ENABLED", true), OnTelemetryEnabled, SetScope::GLOBAL);
+	config.AddExtensionOption("quack_oauth_telemetry_key",
+	                          "PostHog API key for telemetry, see https://erpl.io/telemetry for details.",
+	                          LogicalType::VARCHAR,
+	                          EnvStringDefault("QUACK_OAUTH_TELEMETRY_KEY",
+	                                           "phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t"),
+	                          OnTelemetryKey, SetScope::GLOBAL);
+#endif
 }
 
 } // namespace duckdb

--- a/test/sql/oauth_settings.test
+++ b/test/sql/oauth_settings.test
@@ -16,6 +16,8 @@ require quack_oauth
 #   R-C-2  quack_oauth_renew_skew_s = 60
 #   R-N-4  quack_oauth_trust_plaintext = false
 #   S-7b.2 quack_oauth_server_secret_name = '' (validator's server-SECRET selector)
+#          quack_oauth_telemetry_enabled = true  (opt-out via SET = false)
+#          quack_oauth_telemetry_key = '<DataZoo PostHog project key>'
 query II
 SELECT name, value FROM duckdb_settings() WHERE name LIKE 'quack_oauth%' ORDER BY name;
 ----
@@ -27,6 +29,8 @@ quack_oauth_policy_default	deny
 quack_oauth_provider	generic
 quack_oauth_renew_skew_s	60
 quack_oauth_server_secret_name	(empty)
+quack_oauth_telemetry_enabled	true
+quack_oauth_telemetry_key	phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t
 quack_oauth_trust_plaintext	false
 quack_oauth_validation_mode	jwks
 


### PR DESCRIPTION
## Summary

- Wires the shared **`posthog-telemetry`** submodule (same SHA `../erpl-web` ships) into `quack-oauth`, so the three DataZoo DuckDB extensions report adoption signal to the same PostHog project.
- Emits **`extension_load`** on every `LOAD` and **`function_execution`** at the entry of each of the 10 user-facing functions (8 scalars + 3 table functions in `diagnose.cpp`). No tokens, claims, SQL, SECRET fields, or IdP URLs are sent.
- Adds two GLOBAL settings: **`quack_oauth_telemetry_enabled`** (BOOLEAN, default `true`, env `QUACK_OAUTH_TELEMETRY_ENABLED`) and **`quack_oauth_telemetry_key`** (VARCHAR, default the shared DataZoo key, env `QUACK_OAUTH_TELEMETRY_KEY`).

## Opt-out (either path is enough)

```sql
-- per-database
SET quack_oauth_telemetry_enabled = false;
```

```bash
# machine-wide; also honoured by erpl and erpl-web
export DATAZOO_DISABLE_TELEMETRY=1
```

Documented in `README.md` under the new **Telemetry** section.

## Wasm

The submodule's HTTP path uses `duckdb_httplib_openssl::SSLClient` (native only). `add_subdirectory(posthog-telemetry)`, the `#include "telemetry.hpp"` in wasm-safe files, and the two wasm-safe call sites (`check_authorization_function.cpp`, `diagnose.cpp`) are all guarded with `#ifndef EMSCRIPTEN` / `if(NOT EMSCRIPTEN)`. Native-only files call unconditionally (they don't compile on wasm anyway).

## Test plan

- [x] `GEN=ninja make` — clean build, links posthog_telemetry into both static and loadable targets
- [x] `make test` — 11 SQL tests passing, 1 skip (`require quack`)
- [x] `make unit_test` — 228 Catch2 cases / 806 assertions
- [x] `make smoke_static` — no new dynamic deps (only platform libs)
- [x] `SELECT name, value FROM duckdb_settings() WHERE name LIKE 'quack_oauth_telemetry%'` shows both new settings
- [x] `SET quack_oauth_telemetry_enabled = false; SELECT * FROM quack_oauth_diagnose();` runs without contacting PostHog
- [ ] Wasm build — gated by `#ifndef EMSCRIPTEN`; verify in CI matrix

## Notes

Pattern mirrors `../erpl-web/CMakeLists.txt` + `../erpl-web/src/erpl_web_extension.cpp`. The two settings, the two callbacks (`OnTelemetryEnabled`, `OnTelemetryKey`), and the `SetAPIKey` + `CaptureExtensionLoad` order at the top of `LoadInternal` are direct ports.