### PR TITLE
fix(ci): force C++17 for the whole DuckDB build (fixes v1.5.3 link error)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,31 @@ Explicit baselines (consistent with the references above):
   test binary), which otherwise inherits DuckDB's `-std=c++14`. See
   `../erpl-web/CMakeLists.txt:168-171` for the proven sibling
   pattern and our own `CMakeLists.txt` for the live wiring.
+- **The cached `CMAKE_CXX_STANDARD=11` breaks the v1.5.3 build in two
+  places; force C++17 for the WHOLE build in `extension_config.cmake`.**
+  DuckDB's root CMake does `set(CMAKE_CXX_STANDARD "11" CACHE STRING ...)`,
+  and a plain `set(... CACHE ...)` in our `CMakeLists.txt` is a no-op
+  against an already-populated cache (see the gotcha above), so by default
+  every DuckDB TU compiles below C++17. Symptoms:
+    1. **Linux/GCC**: linking quack_oauth statically into DuckDB drags
+       `posthog-telemetry`'s **PUBLIC** `cxx_std_17` into DuckDB's own
+       `tools/plan_serializer`, so that one tool compiles as C++17 while
+       `libduckdb_static` stays C++11. `BufferedFileWriter::DEFAULT_OPEN_FLAGS`
+       (a `static constexpr` member *with* a deprecated out-of-line
+       definition) is then COMDAT-weak on one side and a strong symbol on
+       the other → `multiple definition` link error.
+    2. **Windows/MSVC** (VS2026 runners): DuckDB's bundled `fmt` uses inline
+       variables, rejected without `/std:c++17` (`error C7525`); at
+       `CMAKE_CXX_STANDARD=11` CMake emits no `/std` flag on MSVC at all.
+  (v1.4.4 LTS Linux is unaffected — the header differs.) **Fix:**
+  `set(CMAKE_CXX_STANDARD 17 CACHE STRING "" FORCE)` at the top of
+  `extension_config.cmake`. That file is `include()`d from
+  extension-ci-tools' `extension_build_tools.cmake` (via
+  `DUCKDB_EXTENSION_CONFIGS`) **before** DuckDB's `add_subdirectory(src/tools)`
+  and `add_third_party(fmt)`, so the FORCE lands in time and the whole build
+  agrees on C++17 (no weak/strong split; MSVC gets `/std:c++17`). Our
+  `CMakeLists.txt:13` set is too late (it runs at the extension subdir, after
+  src/tools are configured) — the FORCE must be in `extension_config.cmake`.
 - **Google's `tokeninfo` returns numeric claims as JSON strings**, not
   numbers: `"exp": "1735689600"` rather than `"exp": 1735689600`. Any
   parser that demands `picojson::value::is<std::int64_t>()` will see

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,6 +1,30 @@
-# This file is included by DuckDB's build system. It specifies which extension to load
+# This file is included by DuckDB's build system. It specifies which extension to load.
+#
+# DuckDB caches CMAKE_CXX_STANDARD=11 (duckdb/CMakeLists.txt) and a plain
+# `set(... CACHE ...)` in our own CMakeLists is a no-op against an already
+# populated cache, so the whole of DuckDB compiles below C++17 by default.
+# That single fact breaks the v1.5.3 build in two different ways:
+#
+#   * Linux/GCC: linking quack_oauth statically into DuckDB drags
+#     posthog_telemetry's PUBLIC cxx_std_17 requirement into DuckDB's own
+#     `plan_serializer` tool, so that one tool compiles as C++17 while
+#     `libduckdb_static` stays C++11. `BufferedFileWriter::DEFAULT_OPEN_FLAGS`
+#     is then a COMDAT-weak symbol on one side and a strong out-of-line
+#     definition on the other -> "multiple definition" link error.
+#   * Windows/MSVC (VS2026 runners): DuckDB's bundled `fmt` uses inline
+#     variables, which MSVC rejects without `/std:c++17` (error C7525). At
+#     CMAKE_CXX_STANDARD=11 CMake emits no `/std` flag at all on MSVC.
+#
+# Forcing the standard to C++17 for the ENTIRE build fixes both: every TU
+# (incl. plan_serializer and fmt) agrees on C++17, so the weak/strong symbol
+# split disappears and MSVC gets `/std:c++17`. This must happen before DuckDB
+# configures `src`/`tools`/the third-party libs -- this file is included from
+# extension_build_tools.cmake (DUCKDB_EXTENSION_CONFIGS) well before those
+# add_subdirectory() calls, so the FORCE lands in time.
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to enforce" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "" FORCE)
 
-# Extension from this repo
+# Extension from this repo.
 duckdb_extension_load(quack_oauth
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
 )


### PR DESCRIPTION
## Problem

CI went red on `main` after the PostHog-telemetry commit (`412cc46`). The **v1.4.4 LTS** matrix was green; the **v1.5.3** matrix failed at *Build extension* on Linux amd64 + arm64:

```
ld: libduckdb_static.a(ub_duckdb_common_serializer.cpp.o): multiple definition of
  'duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS';
  tools/.../plan_serializer.cpp.o: first defined here
```

## Root cause — one fact, two symptoms

DuckDB caches `CMAKE_CXX_STANDARD=11`, and a plain `set(... CACHE ...)` in our `CMakeLists.txt` is a no-op against an already-populated cache. So **all of DuckDB compiles below C++17 by default**, which breaks the v1.5.3 build in two ways:

1. **Linux/GCC (the reported failure):** statically linking `quack_oauth` into DuckDB drags `posthog_telemetry`'s **PUBLIC `cxx_std_17`** requirement into DuckDB's own `tools/plan_serializer`, compiling that one tool as C++17 while `libduckdb_static` stays C++11. `BufferedFileWriter::DEFAULT_OPEN_FLAGS` (a `static constexpr` member with a deprecated out-of-line definition) is then a COMDAT-weak symbol on one side and a strong symbol on the other → `multiple definition`.
2. **Windows/MSVC:** DuckDB's bundled `fmt` uses inline variables, rejected by MSVC without `/std:c++17` (`C7525`); at standard 11 CMake emits no `/std` flag on MSVC.

## Fix

Force `CMAKE_CXX_STANDARD=17` for the **entire** build, in `extension_config.cmake`:

```cmake
set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to enforce" FORCE)
set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "" FORCE)
```

That file is `include()`d (via `DUCKDB_EXTENSION_CONFIGS`) **before** DuckDB configures `src`/`tools`/`fmt`, so the FORCE lands in time and every TU agrees on C++17 — the weak/strong symbol split disappears. Static linkage is preserved, so SQL tests still run as built-in (no autoloading shim, no `DONT_LINK`). `CMakeLists.txt:13` was too late (it runs at the extension subdir, after `src`/`tools` are configured) — hence the FORCE in `extension_config.cmake`. Gotcha documented in `CLAUDE.md`.

## Verification

Local (clean release build): `plan_serializer`/`duckdb`/`unittest` link cleanly; `make test` = 168 assertions / 11 cases (+1 skipped quack-swap); `make unit_test` = 806 assertions; `smoke_static` clean; cache shows `CMAKE_CXX_STANDARD=17`.

CI: **v1.5.3 and v1.4.4 LTS are green on Linux, macOS, and Wasm** — no regression on any previously-green job.

## Known red: Windows (separate, environmental — tracked)

Both Windows jobs fail due to the `windows-latest` → `windows-2025-vs2026` (VS2026) runner migration (~June 2026), **not** this change — they were green on May 28 and would break `main` identically:
- **v1.5.3:** the C++17 fix clears `C7525`, but DuckDB v1.5.3's `fmt` then hits `stdext::checked_array_iterator`, **removed in VS2026's STL** — unfixable by a compiler flag.
- **LTS:** MinGW gcc 15.2.0 ↔ MSVC-built OpenSSL ABI mismatch (`__security_cookie`).

Fix requires pinning the runner to `windows-2022`, which our `extension-ci-tools` version can't express without a fork. Tracked in #5 for a dedicated effort / upstream report.
