### PR TITLE
deps: bump posthog-telemetry — skip queue drain at shutdown (fixes teardown SIGSEGV)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,25 @@ Explicit baselines (consistent with the references above):
   quoted before substitution — see `QuoteQualifiedIdentifier` in
   `src/policy_table.cpp`; never concatenate user-influenced names
   (incl. SECRET fields) directly into SQL.
+- **No new network I/O from atexit/static-teardown paths** (posthog-
+  telemetry SIGSEGV, July 2026). `atexit` handlers and function-local
+  static destructors share one LIFO registration list: any static
+  initialized *after* your handler was registered is destroyed *before*
+  the handler runs. posthog-telemetry's shutdown handler drained its
+  event queue at exit, constructing new httplib `Client`s whose ctor
+  uses a function-local static regex — first initialized by the
+  worker's first POST, i.e. after the handler registration — so the
+  drain hit a destroyed regex: deterministic SIGSEGV in
+  `duckdb_re2::RE2::Match` after "All tests passed" on the v1.5.3
+  linux_amd64 CI job (exit 139; v1.4.4 LTS unaffected). Ordering
+  against OpenSSL cleanup alone is not enough. Rules: a shutdown
+  handler may join/stop threads but must not start new work; if exit-
+  time code must touch a lazily-initialized static, force-initialize
+  it *before* registering the handler (the `OPENSSL_init_ssl`-then-
+  `atexit` trick). Fixed in DataZooDE/posthog-telemetry#4. When a
+  teardown crash strikes only after tests pass, run
+  `./build/release/test/unittest "test/*"` under gdb — the suite
+  passing means the repro is free.
 
 ## Submodules
 


### PR DESCRIPTION
## Why main is red

The 0433745 pin (#7) still segfaults at process exit on `Build extension binaries (v1.5.3) / Linux linux_amd64`: all SQL tests pass, then `make test_release` dies with SIGSEGV. Root cause (reproduced locally, gdb):

```
duckdb_re2::RE2::Match(...)                              ← dead function-local static regex
duckdb_httplib_openssl::Client::Client(...)
duckdb::PostHogProcess(...)
duckdb::TelemetryTaskQueue<PostHogEvent>::ProcessQueue() ← draining queue at exit
```

0433745's atexit handler orders telemetry shutdown before OpenSSL cleanup, but `Stop()` **drains** the queue — constructing new httplib `Client`s whose URL-parsing regex (a function-local static, initialized *after* the atexit registration, hence destroyed *before* the handler runs) is already dead. Every quack_oauth scalar-function call during the test run enqueues an event, so the drain is guaranteed to fire.

## New pin

DataZooDE/posthog-telemetry#4 (`4cd2256`):
- `Stop()` discards pending tasks — no new network I/O once shutdown begins
- `Instance()` pre-warms httplib's function-local statics before registering the atexit handler (protects in-flight requests too)

> **Note:** pinned to the PR-branch head. If posthog-telemetry#4 is squash-merged, re-pin to the resulting main SHA before merging this.

## Verification

- `./build/release/test/unittest "test/*"` (the exact CI command): **exit 139 on every run** with the old pin → **exit 0 on 5/5 consecutive runs** with this pin, all tests passing
- posthog-telemetry's own suite: 64/64 tests pass on Linux/macOS/Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/quack-oauth/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785743027&installation_id=142929061&pr_number=8&repository=DataZooDE%2Fquack-oauth&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fquack-oauth%2Fpull%2F8&signature=1cf9038250c7b08017081fe3e15f6517d729aa819142fcba32f704261fd34e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->