### PR TITLE
feat(telemetry): adopt schema-2 telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,84 @@
+# quack_oauth Telemetry
+
+`quack_oauth` collects **anonymous, privacy-preserving usage telemetry** so we
+can see which capabilities are used, on which platforms, and where they load —
+and prioritise accordingly. It is **on by default** and **trivial to turn off**.
+
+Telemetry is emitted through the shared
+[`DataZooDE/posthog-telemetry`](https://github.com/DataZooDE/posthog-telemetry)
+library and follows the cross-product **`telemetry_schema: 2`** envelope
+(`posthog-telemetry/TELEMETRY-SCHEMA.md`). It uses the same key, the same
+library, and the same opt-out paths as `../erpl` and `../erpl-web`. Ingestion is
+the EU PostHog cloud.
+
+## How to turn it off
+
+Any one of these fully short-circuits telemetry — when disabled, **nothing
+leaves the machine** (the opt-out is enforced at the transport, not just at the
+call sites):
+
+```sql
+SET quack_oauth_telemetry_enabled = false;   -- DuckDB setting (per session)
+```
+
+```bash
+export DATAZOO_DISABLE_TELEMETRY=1            -- environment (1|true|yes)
+```
+
+The setting also has an environment default: `QUACK_OAUTH_TELEMETRY_ENABLED=0`
+starts the extension with telemetry already off.
+
+## The guarantee: bounded, enumerated, non-PII
+
+Every property we send is **either** a constant drawn from a small,
+code-controlled enumeration **or** a pure number (durations, counts). The
+library additionally clamps every outgoing string to a fixed byte cap as a
+backstop.
+
+We **never** send: tokens, access/refresh/ID tokens, client secrets, secret
+names, issuer / audience / JWKS URLs, principal or user identifiers, claims, SQL
+text, function arguments, or OAuth/OIDC **error messages**. The only function
+identifiers transmitted are the fixed, code-controlled `quack_oauth_*` names
+listed below — never their inputs or outputs.
+
+## What is collected
+
+### Envelope (attached to every event)
+
+`product` (`quack_oauth`), `product_version`, `product_edition` (`oss`),
+`telemetry_schema` (`2`), `duckdb_version`, `os`, `arch`, `platform`, `is_ci`,
+`is_container`, a per-process `$session_id`, and — once associated — the
+`deployment` group. `distinct_id` is the SHA-256 of a machine id: a **stable,
+pseudonymous** identifier, not tied to any personal data.
+
+### Events
+
+| Event | When | Properties (beyond the envelope) |
+|---|---|---|
+| `extension_loaded` | the `quack_oauth` extension loads | — |
+| `function_executed` | a `quack_oauth_*` function runs — **aggregated** per function per session (not per row) | `function_name`, `call_count`, `duration_ms_p50` |
+
+`quack_oauth` associates only the `deployment` group. It has no license key, so
+no `account` group is associated.
+
+### Instrumented functions (the `function_name` enumeration)
+
+`quack_oauth_check_authorization`, `quack_oauth_check_token`,
+`quack_oauth_acquire`, `quack_oauth_login`, `quack_oauth_logout`,
+`quack_oauth_refresh`, `quack_oauth_device_login`, `quack_oauth_diagnose`,
+`quack_oauth_audit_log`, `quack_oauth_current_principal`.
+
+## Function-call aggregation
+
+DuckDB function calls are recorded via `RecordFunctionCall(function_name)`, which
+aggregates in-process into a single `function_executed` event per function per
+session (carrying `call_count` and `duration_ms_p50`). Each capture site sits at
+bind or at the top of the per-chunk callback — never on a per-row path — so a
+large scan produces O(1) telemetry rows, not a firehose.
+
+## Teardown safety
+
+The telemetry worker discards any queued events at process exit rather than
+draining them (no new HTTPS work starts from the `atexit` / static-teardown
+path). This avoids the deterministic shutdown SIGSEGV described in
+`DataZooDE/posthog-telemetry#4`.

--- a/src/acquire_function.cpp
+++ b/src/acquire_function.cpp
@@ -130,7 +130,7 @@ static string DoAcquire(ClientContext &context, const string &secret_name) {
 }
 
 static void AcquireScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_acquire");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_acquire");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto tok = DoAcquire(context, secret_name_str.GetString());

--- a/src/check_authorization_function.cpp
+++ b/src/check_authorization_function.cpp
@@ -62,7 +62,7 @@ static int64_t LookupClockSkew(ClientContext &context) {
 
 static void CheckAuthorizationScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_authorization");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_check_authorization");
 #endif
 	auto &context = state.GetContext();
 	auto &shared_state = GetQuackOauthState();

--- a/src/check_token_function.cpp
+++ b/src/check_token_function.cpp
@@ -395,7 +395,7 @@ static void RunValidationLoop(Vector &tokens, idx_t count, Vector &result, Clien
 // cache the extracted Principal in QuackOauthState::session_principals so
 // the companion authz scalar can look it up.
 static void ValidateChunk(Vector &tokens, idx_t count, Vector &result, ClientContext &context, Vector *session_ids) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_token");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_check_token");
 	const auto cfg = LoadServerConfig(context);
 
 	quack_oauth::VerifyOptions opts;

--- a/src/device_login_function.cpp
+++ b/src/device_login_function.cpp
@@ -110,7 +110,7 @@ string DoDeviceLoginImpl(ClientContext &context, const string &secret_name) {
 }
 
 static void DeviceLoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_device_login");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_device_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoDeviceLoginImpl(context, secret_name_str.GetString());

--- a/src/diagnose.cpp
+++ b/src/diagnose.cpp
@@ -55,7 +55,7 @@ static string ReadSetting(ClientContext &context, const string &key) {
 static unique_ptr<FunctionData> DiagnoseBind(ClientContext &context, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_diagnose");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_diagnose");
 #endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	names = {"component", "status", "detail"};
@@ -215,7 +215,7 @@ struct AuditLogGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> AuditLogBind(ClientContext &, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_audit_log");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_audit_log");
 #endif
 	return_types = {LogicalType::BIGINT,  LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
@@ -286,7 +286,7 @@ struct CurrentPrincipalGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> CurrentPrincipalBind(ClientContext &, TableFunctionBindInput &,
                                                      vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_current_principal");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_current_principal");
 #endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::LIST(LogicalType::VARCHAR), LogicalType::BIGINT};

--- a/src/login_function.cpp
+++ b/src/login_function.cpp
@@ -64,7 +64,7 @@ string DoLogin(ClientContext &context, const string &secret_name) {
 }
 
 static void LoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_login");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoLogin(context, secret_name_str.GetString());

--- a/src/logout_function.cpp
+++ b/src/logout_function.cpp
@@ -40,7 +40,7 @@ static bool DoLogout(ClientContext &context, const string &secret_name) {
 }
 
 static void LogoutScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_logout");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_logout");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		return DoLogout(context, secret_name_str.GetString());

--- a/src/quack_oauth_extension.cpp
+++ b/src/quack_oauth_extension.cpp
@@ -32,6 +32,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// settings registration follows so that user-supplied
 	// `quack_oauth_telemetry_key` overrides the default via OnTelemetryKey.
 	PostHogTelemetry::Instance().SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
+	PostHogTelemetry::Instance().SetProduct("quack_oauth", "2026.05.28", "oss");
+	PostHogTelemetry::Instance().AssociateGroup("deployment", PostHogTelemetry::GetDistinctId());
 	PostHogTelemetry::Instance().CaptureExtensionLoad("quack_oauth", QuackOauthExtension().Version());
 #endif
 	RegisterQuackOauthSettings(config);

--- a/src/refresh_function.cpp
+++ b/src/refresh_function.cpp
@@ -66,7 +66,7 @@ string DoRefresh(ClientContext &context, const string &secret_name) {
 }
 
 static void RefreshScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_refresh");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_refresh");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoRefresh(context, secret_name_str.GetString());


### PR DESCRIPTION
## Summary

Migrates `quack_oauth` telemetry onto the shared `posthog-telemetry`
schema-2, analysis-first API — aligning it with `../erpl` / `../erpl-web`.

- Bump the `posthog-telemetry` submodule to the analysis-first API.
- Register product identity and the deployment group at load:
  `SetProduct("quack_oauth", ..., "oss")` + `AssociateGroup("deployment", ...)`
  in `LoadInternal`.
- Migrate every capture site from `CaptureFunctionExecution(...)` to
  `RecordFunctionCall(...)`, which aggregates in-process into a single
  `function_executed` event per function per session (`call_count`,
  `duration_ms_p50`) instead of one row per call.
- Add `TELEMETRY.md` documenting exactly what is collected, the opt-out
  paths, and the privacy guarantee.

## Privacy guarantee

Only enumerated or numeric properties ever leave the machine. Every sent
property is either a constant from a small, code-controlled enumeration
(e.g. the fixed `quack_oauth_*` `function_name` set, product/edition) or a
pure number (durations, counts); the library additionally clamps every
outgoing string to a fixed byte cap. We never transmit tokens, secrets,
secret names, issuer/audience/JWKS URLs, principal/user identifiers,
claims, SQL text, function arguments, or OAuth/OIDC error messages.

Telemetry stays on by default and is trivial to disable
(`SET quack_oauth_telemetry_enabled = false`, `DATAZOO_DISABLE_TELEMETRY=1`,
or `QUACK_OAUTH_TELEMETRY_ENABLED=0`); the opt-out is enforced at the
transport, so when disabled nothing leaves the machine.

Teardown safety from `posthog-telemetry#4` is preserved: queued events are
discarded at process exit rather than drained (no new HTTPS work from the
`atexit` / static-teardown path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/quack-oauth/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786520194&installation_id=142929061&pr_number=9&repository=DataZooDE%2Fquack-oauth&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fquack-oauth%2Fpull%2F9&signature=10720e8526482fb3b24f8d3f7c2156a08c1c846a14cd0bc377125eae1c7d74d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->