### PR TITLE
chore: bump DuckDB to v1.5.5 (keep v1.4 LTS)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,18 +19,18 @@
 #
 # Build matrix:
 #   - duckdb-stable-* jobs build against the current stable DuckDB
-#     (v1.5.3). The repo's submodules are pinned to this version.
+#     (v1.5.5). The repo's submodules are pinned to this version.
 #   - duckdb-lts-* jobs build against the 1.4 LTS line: DuckDB *source*
-#     v1.4.4 (via duckdb_version), but using the v1.5.3 extension-ci-tools
-#     reusable workflow + tooling (the `@v1.5.3` ref and ci_tools_version).
-#     Why not @v1.4.4: that workflow leaves the Windows compiler to
+#     v1.4.5 (via duckdb_version), but using the v1.5.5 extension-ci-tools
+#     reusable workflow + tooling (the `@v1.5.5` ref and ci_tools_version).
+#     Why not @v1.4.5: that workflow leaves the Windows compiler to
 #     autodetect, and the current windows-latest image then picks MinGW g++,
 #     which (a) trips the C++17 std::byte vs Win-SDK `byte` ambiguity and
-#     (b) can't link the MSVC-built vcpkg OpenSSL. The v1.5.3 workflow pins
+#     (b) can't link the MSVC-built vcpkg OpenSSL. The v1.5.5 workflow pins
 #     the Windows compiler to MSVC `cl`, matching the stable job, so the LTS
 #     build is green on the same runners. We still verify 1.4 LTS API
 #     compatibility because the DuckDB headers/library compiled against are
-#     v1.4.4 -- only the build tooling is shared with stable.
+#     v1.4.5 -- only the build tooling is shared with stable.
 # Both pairs publish under their own /v<ver>/ path on S3 via
 # scripts/extension-upload.sh -- there are no naming collisions.
 #
@@ -53,21 +53,21 @@ concurrency:
 
 jobs:
   duckdb-stable-build:
-    name: Build extension binaries (v1.5.3)
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.3
+    name: Build extension binaries (v1.5.5)
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.5
     with:
-      duckdb_version: v1.5.3
-      ci_tools_version: v1.5.3
+      duckdb_version: v1.5.5
+      ci_tools_version: v1.5.5
       extension_name: quack_oauth
       exclude_archs: 'windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
 
   duckdb-stable-deploy:
-    name: Deploy extension binaries (v1.5.3)
+    name: Deploy extension binaries (v1.5.5)
     needs: duckdb-stable-build
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.3
+      duckdb_version: v1.5.5
       extension_name: quack_oauth
       exclude_archs: 'windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
       # Mirror erpl-web: push on tag-or-main. PRs and feature branches
@@ -76,26 +76,26 @@ jobs:
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
   duckdb-lts-build:
-    name: Build extension binaries (v1.4.4 LTS)
-    # DuckDB source v1.4.4, but built with the v1.5.3 tooling (forces MSVC cl
+    name: Build extension binaries (v1.4.5 LTS)
+    # DuckDB source v1.4.5, but built with the v1.5.5 tooling (forces MSVC cl
     # on Windows). See the header comment for the rationale.
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.5
     with:
-      duckdb_version: v1.4.4
-      ci_tools_version: v1.5.3
+      duckdb_version: v1.4.5
+      ci_tools_version: v1.5.5
       extension_name: quack_oauth
       exclude_archs: 'windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
 
   duckdb-lts-deploy:
-    name: Deploy extension binaries (v1.4.4 LTS)
+    name: Deploy extension binaries (v1.4.5 LTS)
     needs: duckdb-lts-build
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.4.4
+      duckdb_version: v1.4.5
       # Match the LTS build job's tooling so the deploy arch matrix lines up
       # with the artifacts the build produced (see duckdb-lts-build).
-      ci_tools_version: v1.5.3
+      ci_tools_version: v1.5.5
       extension_name: quack_oauth
       exclude_archs: 'windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Bumps the `duckdb` submodule (v1.5.3 -> v1.5.5) and updates
`.github/workflows/MainDistributionPipeline.yml` accordingly, while
keeping the dual v1.4 LTS / v1.5 stable release matrix intact.

### Submodule
- `duckdb`: v1.5.3 -> v1.5.5

### Workflow edits (`.github/workflows/MainDistributionPipeline.yml`)
- `duckdb-stable-build` / `duckdb-stable-deploy`: `duckdb_version`,
  `ci_tools_version`, and the `uses: ...@v1.5.3` ref all bumped to
  `v1.5.5`.
- `duckdb-lts-build` / `duckdb-lts-deploy`: LTS `duckdb_version`
  normalized `v1.4.4` -> `v1.4.5`. `ci_tools_version` and the
  `uses: ...@v1.5.3` ref bumped to `v1.5.5` (the LTS jobs intentionally
  reuse the stable extension-ci-tools tooling for the MSVC-`cl`
  Windows fix — see the file's header comment, unchanged).
- Human-readable `name:`/comment strings referencing the old versions
  (`v1.5.3`, `v1.4.4`) updated to match (`v1.5.5`, `v1.4.5`).
- No jobs added, removed, or reordered; the v1.4 LTS jobs remain.

No other genuine version pins were found (checked `vcpkg.json`,
`Makefile`, `CMakeLists.txt`/`extension_config.cmake` for stray
`DUCKDB_GIT_VERSION`/version literals — none present outside the
workflow file and the submodule pointer).

## Local verification on bigfox

- **Build**: `buildStatus=pass` — clean `GEN=ninja make release` build
  (no GCC-16 ODR/link issues this time), producing
  `build/release/extension/quack_oauth/quack_oauth.duckdb_extension`.
- **Tests**: `testStatus=pass` — `make test_release`: all SQL tests
  passed (168 assertions in 11 test cases, 1 test skipped via
  `require quack` as expected without the sibling `quack` extension
  installed).

## Test plan

- [x] `duckdb` submodule pinned to `v1.5.5`
- [x] `GEN=ninja make release` builds cleanly, extension artifact present
- [x] `make test_release` — all SQL tests pass
- [ ] CI green on both the `duckdb-stable-*` (v1.5.5) and
      `duckdb-lts-*` (v1.4.5) job pairs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/quack-oauth/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475567&installation_model_id=425457&pr_number=11&repository=DataZooDE%2Fquack-oauth&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fquack-oauth%2Fpull%2F11&signature=d7a7a2d965f69d03689354fc792ffea00947a90ffab7c434f37a91e04ede925f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->