### PR TITLE
feat: add feedback banner and issue links to errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "posthog-telemetry"]
 	path = posthog-telemetry
 	url = https://github.com/DataZooDE/posthog-telemetry.git
+[submodule "datazoo-banner"]
+	path = datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,14 @@ include_directories(./duckdb/third_party/httplib)
 if(NOT EMSCRIPTEN)
     include_directories(posthog-telemetry/include)
     add_subdirectory(posthog-telemetry)
+    # Count a printed banner as a banner_shown event. Only where telemetry is
+    # actually linked -- on wasm the banner still compiles and is simply inert,
+    # since a browser has no terminal to print to.
+    set(DATAZOO_BANNER_TELEMETRY ON CACHE BOOL "" FORCE)
 endif()
+
+# Feedback banner (header-only, no dependencies, builds everywhere).
+add_subdirectory(datazoo-banner)
 
 # Pure-logic sources (no DuckDB includes) -- compiled into BOTH the extension
 # and the Catch2 unit-test binary. See docs/IMPLEMENTATION.md section 2.3.
@@ -113,11 +120,11 @@ target_compile_features(${EXTENSION_NAME} PRIVATE cxx_std_17)
 target_compile_features(${LOADABLE_EXTENSION_NAME} PRIVATE cxx_std_17)
 
 if(NOT EMSCRIPTEN)
-  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry)
-  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry)
+  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry datazoo_banner)
+  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp posthog_telemetry datazoo_banner)
 else()
-  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
-  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp)
+  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp datazoo_banner)
+  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto jwt-cpp::jwt-cpp datazoo_banner)
 endif()
 
 install(

--- a/README.md
+++ b/README.md
@@ -647,6 +647,20 @@ SELECT * FROM quack_oauth_diagnose();
 The `token_hash` column is always the first 8 hex of `sha256(token)` —
 **never** the raw bearer.
 
+## Feedback
+
+If `quack_oauth` misbehaves or does something surprising, please
+[open an issue](https://github.com/DataZooDE/quack-oauth/issues). OAuth breaks against
+real IdP configurations we cannot reproduce here — Entra app roles, Google's
+string-typed numeric claims, Keycloak realms — so a report with your setup is the
+fastest path to a fix. Every error the extension raises ends with that link.
+
+If it saved you time, a star on the repo helps other people find it.
+
+The first time you load the extension in an interactive terminal each day, a small
+banner says the same thing. It never prints when output is piped, in notebooks, or in
+CI. Silence it with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.
+
 ## Telemetry
 
 The extension sends anonymous usage events to a DataZoo-owned PostHog

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,84 @@
+# quack_oauth Telemetry
+
+`quack_oauth` collects **anonymous, privacy-preserving usage telemetry** so we
+can see which capabilities are used, on which platforms, and where they load —
+and prioritise accordingly. It is **on by default** and **trivial to turn off**.
+
+Telemetry is emitted through the shared
+[`DataZooDE/posthog-telemetry`](https://github.com/DataZooDE/posthog-telemetry)
+library and follows the cross-product **`telemetry_schema: 2`** envelope
+(`posthog-telemetry/TELEMETRY-SCHEMA.md`). It uses the same key, the same
+library, and the same opt-out paths as `../erpl` and `../erpl-web`. Ingestion is
+the EU PostHog cloud.
+
+## How to turn it off
+
+Any one of these fully short-circuits telemetry — when disabled, **nothing
+leaves the machine** (the opt-out is enforced at the transport, not just at the
+call sites):
+
+```sql
+SET quack_oauth_telemetry_enabled = false;   -- DuckDB setting (per session)
+```
+
+```bash
+export DATAZOO_DISABLE_TELEMETRY=1            -- environment (1|true|yes)
+```
+
+The setting also has an environment default: `QUACK_OAUTH_TELEMETRY_ENABLED=0`
+starts the extension with telemetry already off.
+
+## The guarantee: bounded, enumerated, non-PII
+
+Every property we send is **either** a constant drawn from a small,
+code-controlled enumeration **or** a pure number (durations, counts). The
+library additionally clamps every outgoing string to a fixed byte cap as a
+backstop.
+
+We **never** send: tokens, access/refresh/ID tokens, client secrets, secret
+names, issuer / audience / JWKS URLs, principal or user identifiers, claims, SQL
+text, function arguments, or OAuth/OIDC **error messages**. The only function
+identifiers transmitted are the fixed, code-controlled `quack_oauth_*` names
+listed below — never their inputs or outputs.
+
+## What is collected
+
+### Envelope (attached to every event)
+
+`product` (`quack_oauth`), `product_version`, `product_edition` (`oss`),
+`telemetry_schema` (`2`), `duckdb_version`, `os`, `arch`, `platform`, `is_ci`,
+`is_container`, a per-process `$session_id`, and — once associated — the
+`deployment` group. `distinct_id` is the SHA-256 of a machine id: a **stable,
+pseudonymous** identifier, not tied to any personal data.
+
+### Events
+
+| Event | When | Properties (beyond the envelope) |
+|---|---|---|
+| `extension_loaded` | the `quack_oauth` extension loads | — |
+| `function_executed` | a `quack_oauth_*` function runs — **aggregated** per function per session (not per row) | `function_name`, `call_count`, `duration_ms_p50` |
+
+`quack_oauth` associates only the `deployment` group. It has no license key, so
+no `account` group is associated.
+
+### Instrumented functions (the `function_name` enumeration)
+
+`quack_oauth_check_authorization`, `quack_oauth_check_token`,
+`quack_oauth_acquire`, `quack_oauth_login`, `quack_oauth_logout`,
+`quack_oauth_refresh`, `quack_oauth_device_login`, `quack_oauth_diagnose`,
+`quack_oauth_audit_log`, `quack_oauth_current_principal`.
+
+## Function-call aggregation
+
+DuckDB function calls are recorded via `RecordFunctionCall(function_name)`, which
+aggregates in-process into a single `function_executed` event per function per
+session (carrying `call_count` and `duration_ms_p50`). Each capture site sits at
+bind or at the top of the per-chunk callback — never on a per-row path — so a
+large scan produces O(1) telemetry rows, not a firehose.
+
+## Teardown safety
+
+The telemetry worker discards any queued events at process exit rather than
+draining them (no new HTTPS work starts from the `atexit` / static-teardown
+path). This avoids the deterministic shutdown SIGSEGV described in
+`DataZooDE/posthog-telemetry#4`.

--- a/src/acquire_function.cpp
+++ b/src/acquire_function.cpp
@@ -130,7 +130,7 @@ static string DoAcquire(ClientContext &context, const string &secret_name) {
 }
 
 static void AcquireScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_acquire");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_acquire");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto tok = DoAcquire(context, secret_name_str.GetString());

--- a/src/acquire_function.cpp
+++ b/src/acquire_function.cpp
@@ -21,6 +21,7 @@
 #include "refresh_function.hpp"
 #include "secret_accessor.hpp"
 #include "telemetry.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -139,7 +140,8 @@ static void AcquireScalarFun(DataChunk &args, ExpressionState &state, Vector &re
 }
 
 void RegisterQuackOauthAcquire(ExtensionLoader &loader) {
-	ScalarFunction fn("quack_oauth_acquire", {LogicalType::VARCHAR}, LogicalType::VARCHAR, AcquireScalarFun);
+	ScalarFunction fn("quack_oauth_acquire", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, AcquireScalarFun));
 	// Side-effecting + HTTP-bound + idempotent only in the UseCached
 	// branch. Never fold or memoise.
 	fn.stability = FunctionStability::VOLATILE;

--- a/src/check_authorization_function.cpp
+++ b/src/check_authorization_function.cpp
@@ -62,7 +62,7 @@ static int64_t LookupClockSkew(ClientContext &context) {
 
 static void CheckAuthorizationScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_authorization");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_check_authorization");
 #endif
 	auto &context = state.GetContext();
 	auto &shared_state = GetQuackOauthState();

--- a/src/check_authorization_function.cpp
+++ b/src/check_authorization_function.cpp
@@ -26,6 +26,7 @@
 #include "secret_accessor.hpp"
 #include "sql_inspect.hpp"
 #include "tracing.hpp"
+#include "quack_oauth_banner.hpp"
 
 #ifndef EMSCRIPTEN
 #include "telemetry.hpp"
@@ -163,7 +164,8 @@ static void CheckAuthorizationScalarFun(DataChunk &args, ExpressionState &state,
 
 void RegisterQuackOauthCheckAuthorization(ExtensionLoader &loader) {
 	ScalarFunction fn("quack_oauth_check_authorization", {LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                  LogicalType::BOOLEAN, CheckAuthorizationScalarFun);
+	                  LogicalType::BOOLEAN,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, CheckAuthorizationScalarFun));
 	// Emits an audit event per call AND reads from session-keyed in-memory
 	// state that may change between rows. MUST NOT be constant-folded.
 	fn.stability = FunctionStability::VOLATILE;

--- a/src/check_token_function.cpp
+++ b/src/check_token_function.cpp
@@ -33,6 +33,7 @@
 #include "validator.hpp"
 
 #include "duckdb/main/connection.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -552,13 +553,14 @@ void RegisterQuackOauthCheckToken(ExtensionLoader &loader) {
 	// via `SET quack_authentication_function = 'quack_oauth_check_token'`
 	// after `LOAD quack` (slice S-9).
 	ScalarFunctionSet set("quack_oauth_check_token");
-	ScalarFunction fn1({LogicalType::VARCHAR}, LogicalType::BOOLEAN, CheckTokenScalarFun1);
+	ScalarFunction fn1({LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                   DATAZOO_GUARD(QUACK_OAUTH_BANNER, CheckTokenScalarFun1));
 	// Each call may issue an HTTP fetch (JWKS / introspect / tokeninfo) and
 	// always emits audit events. MUST NOT be constant-folded.
 	fn1.stability = FunctionStability::VOLATILE;
 	set.AddFunction(fn1);
 	ScalarFunction fn3({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                   CheckTokenScalarFun3);
+	                   DATAZOO_GUARD(QUACK_OAUTH_BANNER, CheckTokenScalarFun3));
 	fn3.stability = FunctionStability::VOLATILE;
 	set.AddFunction(fn3);
 

--- a/src/check_token_function.cpp
+++ b/src/check_token_function.cpp
@@ -395,7 +395,7 @@ static void RunValidationLoop(Vector &tokens, idx_t count, Vector &result, Clien
 // cache the extracted Principal in QuackOauthState::session_principals so
 // the companion authz scalar can look it up.
 static void ValidateChunk(Vector &tokens, idx_t count, Vector &result, ClientContext &context, Vector *session_ids) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_check_token");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_check_token");
 	const auto cfg = LoadServerConfig(context);
 
 	quack_oauth::VerifyOptions opts;

--- a/src/device_login_function.cpp
+++ b/src/device_login_function.cpp
@@ -110,7 +110,7 @@ string DoDeviceLoginImpl(ClientContext &context, const string &secret_name) {
 }
 
 static void DeviceLoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_device_login");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_device_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoDeviceLoginImpl(context, secret_name_str.GetString());

--- a/src/device_login_function.cpp
+++ b/src/device_login_function.cpp
@@ -21,6 +21,7 @@
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
 #include "telemetry.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -119,7 +120,8 @@ static void DeviceLoginScalarFun(DataChunk &args, ExpressionState &state, Vector
 }
 
 void RegisterQuackOauthDeviceLogin(ExtensionLoader &loader) {
-	ScalarFunction fn("quack_oauth_device_login", {LogicalType::VARCHAR}, LogicalType::VARCHAR, DeviceLoginScalarFun);
+	ScalarFunction fn("quack_oauth_device_login", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, DeviceLoginScalarFun));
 	// Side-effecting (mutates SECRET state, emits audit events) AND
 	// non-idempotent (each call mints a NEW device_code with the IdP).
 	// MUST NOT be constant-folded or memoised across rows.

--- a/src/diagnose.cpp
+++ b/src/diagnose.cpp
@@ -16,6 +16,7 @@
 #include "quack_oauth_state.hpp"
 #include "retry_http_client.hpp"
 #include "secret_accessor.hpp"
+#include "quack_oauth_banner.hpp"
 
 #ifndef EMSCRIPTEN
 #include "telemetry.hpp"
@@ -336,7 +337,8 @@ static void CurrentPrincipalScan(ClientContext &, TableFunctionInput &input, Dat
 
 void RegisterQuackOauthDiagnose(ExtensionLoader &loader) {
 	{
-		TableFunction fn("quack_oauth_diagnose", {}, DiagnoseScan, DiagnoseBind, DiagnoseInit);
+		TableFunction fn("quack_oauth_diagnose", {}, DATAZOO_GUARD(QUACK_OAUTH_BANNER, DiagnoseScan),
+		                 DATAZOO_GUARD(QUACK_OAUTH_BANNER, DiagnoseBind), DiagnoseInit);
 		CreateTableFunctionInfo info(fn);
 		FunctionDescription desc;
 		desc.description = "Health and configuration snapshot for the quack_oauth extension. Returns one row "
@@ -353,8 +355,9 @@ void RegisterQuackOauthDiagnose(ExtensionLoader &loader) {
 	}
 
 	{
-		TableFunction fn("quack_oauth_current_principal", {}, CurrentPrincipalScan, CurrentPrincipalBind,
-		                 CurrentPrincipalInit);
+		TableFunction fn("quack_oauth_current_principal", {},
+		                 DATAZOO_GUARD(QUACK_OAUTH_BANNER, CurrentPrincipalScan),
+		                 DATAZOO_GUARD(QUACK_OAUTH_BANNER, CurrentPrincipalBind), CurrentPrincipalInit);
 		CreateTableFunctionInfo info(fn);
 		FunctionDescription desc;
 		desc.description = "Returns the per-session Principal cache as a typed table (R-S-6): "
@@ -373,7 +376,8 @@ void RegisterQuackOauthDiagnose(ExtensionLoader &loader) {
 	}
 
 	{
-		TableFunction fn("quack_oauth_audit_log", {}, AuditLogScan, AuditLogBind, AuditLogInit);
+		TableFunction fn("quack_oauth_audit_log", {}, DATAZOO_GUARD(QUACK_OAUTH_BANNER, AuditLogScan),
+		                 DATAZOO_GUARD(QUACK_OAUTH_BANNER, AuditLogBind), AuditLogInit);
 		CreateTableFunctionInfo info(fn);
 		FunctionDescription desc;
 		desc.description = "Returns the in-memory audit ring (last N auth decisions) as a typed table. "

--- a/src/diagnose.cpp
+++ b/src/diagnose.cpp
@@ -55,7 +55,7 @@ static string ReadSetting(ClientContext &context, const string &key) {
 static unique_ptr<FunctionData> DiagnoseBind(ClientContext &context, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_diagnose");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_diagnose");
 #endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
 	names = {"component", "status", "detail"};
@@ -215,7 +215,7 @@ struct AuditLogGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> AuditLogBind(ClientContext &, TableFunctionBindInput &,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_audit_log");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_audit_log");
 #endif
 	return_types = {LogicalType::BIGINT,  LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
@@ -286,7 +286,7 @@ struct CurrentPrincipalGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> CurrentPrincipalBind(ClientContext &, TableFunctionBindInput &,
                                                      vector<LogicalType> &return_types, vector<string> &names) {
 #ifndef EMSCRIPTEN
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_current_principal");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_current_principal");
 #endif
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::LIST(LogicalType::VARCHAR), LogicalType::BIGINT};

--- a/src/include/quack_oauth_banner.hpp
+++ b/src/include/quack_oauth_banner.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "datazoo_banner_duckdb.hpp"
+
+// Shared identity for the load banner and the issue-link error footer.
+//
+// External linkage on purpose: DATAZOO_GUARD takes the address as a non-type
+// template argument, and every guarded translation unit should annotate errors
+// against the same object rather than a per-TU copy.
+//
+// Defined in quack_oauth_extension.cpp.
+extern const datazoo::BannerInfo QUACK_OAUTH_BANNER;

--- a/src/login_function.cpp
+++ b/src/login_function.cpp
@@ -64,7 +64,7 @@ string DoLogin(ClientContext &context, const string &secret_name) {
 }
 
 static void LoginScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_login");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_login");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoLogin(context, secret_name_str.GetString());

--- a/src/login_function.cpp
+++ b/src/login_function.cpp
@@ -20,6 +20,7 @@
 #include "secret_accessor.hpp"
 #include "telemetry.hpp"
 #include "token_endpoint.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -73,7 +74,8 @@ static void LoginScalarFun(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 void RegisterQuackOauthLogin(ExtensionLoader &loader) {
-	ScalarFunction fn("quack_oauth_login", {LogicalType::VARCHAR}, LogicalType::VARCHAR, LoginScalarFun);
+	ScalarFunction fn("quack_oauth_login", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, LoginScalarFun));
 	// Side-effecting (writes access_token + expires_at back onto the SECRET)
 	// and HTTP-bound: never fold or memoise across calls.
 	fn.stability = FunctionStability::VOLATILE;

--- a/src/logout_function.cpp
+++ b/src/logout_function.cpp
@@ -18,6 +18,7 @@
 
 #include "secret_accessor.hpp"
 #include "telemetry.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -48,7 +49,8 @@ static void LogoutScalarFun(DataChunk &args, ExpressionState &state, Vector &res
 }
 
 void RegisterQuackOauthLogout(ExtensionLoader &loader) {
-	ScalarFunction fn("quack_oauth_logout", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, LogoutScalarFun);
+	ScalarFunction fn("quack_oauth_logout", {LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, LogoutScalarFun));
 	// Side-effecting (mutates the SECRET): never fold or memoise.
 	fn.stability = FunctionStability::VOLATILE;
 	CreateScalarFunctionInfo info(std::move(fn));

--- a/src/logout_function.cpp
+++ b/src/logout_function.cpp
@@ -40,7 +40,7 @@ static bool DoLogout(ClientContext &context, const string &secret_name) {
 }
 
 static void LogoutScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_logout");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_logout");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, bool>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		return DoLogout(context, secret_name_str.GetString());

--- a/src/quack_oauth_extension.cpp
+++ b/src/quack_oauth_extension.cpp
@@ -1,6 +1,7 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "quack_oauth_extension.hpp"
+#include "quack_oauth_banner.hpp"
 #include "check_authorization_function.hpp"
 #include "diagnose.hpp"
 #include "secrets.hpp"
@@ -21,6 +22,20 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+
+// The build stamps EXT_VERSION_QUACK_OAUTH from the git tag; the fallback keeps
+// the banner honest in local builds that do not, and matches the version
+// SetProduct reports below.
+#ifdef EXT_VERSION_QUACK_OAUTH
+#define QUACK_OAUTH_BANNER_VERSION EXT_VERSION_QUACK_OAUTH
+#else
+#define QUACK_OAUTH_BANNER_VERSION "2026.05.28"
+#endif
+
+// Deliberately outside namespace duckdb: the banner library is DuckDB-agnostic
+// and the guard macro refers to this object from every guarded source file.
+const datazoo::BannerInfo QUACK_OAUTH_BANNER {"quack_oauth", QUACK_OAUTH_BANNER_VERSION,
+                                              "https://github.com/DataZooDE/quack-oauth"};
 
 namespace duckdb {
 
@@ -48,6 +63,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterQuackOauthDeviceLogin(loader);
 	RegisterQuackOauthAcquire(loader);
 #endif
+
+	datazoo::RegisterBannerOption(loader);
+	// Last, so a load that fails earlier never advertises itself. Silent unless
+	// stderr is a terminal and the ~/.duckdb stamp is over a day old.
+	datazoo::ShowBanner(QUACK_OAUTH_BANNER);
 }
 
 void QuackOauthExtension::Load(ExtensionLoader &loader) {

--- a/src/quack_oauth_extension.cpp
+++ b/src/quack_oauth_extension.cpp
@@ -32,6 +32,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// settings registration follows so that user-supplied
 	// `quack_oauth_telemetry_key` overrides the default via OnTelemetryKey.
 	PostHogTelemetry::Instance().SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
+	PostHogTelemetry::Instance().SetProduct("quack_oauth", "2026.05.28", "oss");
+	PostHogTelemetry::Instance().AssociateGroup("deployment", PostHogTelemetry::GetDistinctId());
 	PostHogTelemetry::Instance().CaptureExtensionLoad("quack_oauth", QuackOauthExtension().Version());
 #endif
 	RegisterQuackOauthSettings(config);

--- a/src/refresh_function.cpp
+++ b/src/refresh_function.cpp
@@ -20,6 +20,7 @@
 #include "secret_accessor.hpp"
 #include "telemetry.hpp"
 #include "token_endpoint.hpp"
+#include "quack_oauth_banner.hpp"
 
 namespace duckdb {
 
@@ -75,7 +76,8 @@ static void RefreshScalarFun(DataChunk &args, ExpressionState &state, Vector &re
 }
 
 void RegisterQuackOauthRefresh(ExtensionLoader &loader) {
-	ScalarFunction fn("quack_oauth_refresh", {LogicalType::VARCHAR}, LogicalType::VARCHAR, RefreshScalarFun);
+	ScalarFunction fn("quack_oauth_refresh", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                  DATAZOO_GUARD(QUACK_OAUTH_BANNER, RefreshScalarFun));
 	// Side-effecting (rotates tokens on the SECRET) and HTTP-bound.
 	fn.stability = FunctionStability::VOLATILE;
 	CreateScalarFunctionInfo info(std::move(fn));

--- a/src/refresh_function.cpp
+++ b/src/refresh_function.cpp
@@ -66,7 +66,7 @@ string DoRefresh(ClientContext &context, const string &secret_name) {
 }
 
 static void RefreshScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("quack_oauth_refresh");
+	PostHogTelemetry::Instance().RecordFunctionCall("quack_oauth_refresh");
 	auto &context = state.GetContext();
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t secret_name_str) {
 		const auto iso = DoRefresh(context, secret_name_str.GetString());

--- a/test/sql/quack_oauth_feedback.test
+++ b/test/sql/quack_oauth_feedback.test
@@ -1,0 +1,36 @@
+# name: test/sql/quack_oauth_feedback.test
+# description: The feedback banner's two contracts: errors carry an issue link,
+#              and the banner never writes anything under a test runner.
+# group: [sql]
+
+require quack_oauth
+
+# --- Every error raised by a registered function picks up the issue link, so a
+#     user who hits one is told where to report it without going looking.
+statement error
+SELECT quack_oauth_login('does_not_exist');
+----
+https://github.com/DataZooDE/quack-oauth/issues
+
+# The link is appended, not substituted: the real diagnostic must survive.
+statement error
+SELECT quack_oauth_login('does_not_exist');
+----
+SECRET 'does_not_exist' not found
+
+# --- Errors DuckDB raises before dispatch (binder, catalog, arity) are
+#     deliberately NOT annotated -- they are not ours, and claiming them would
+#     send users to the wrong tracker.
+statement error
+SELECT * FROM quack_oauth_audit_log(NULL);
+----
+Binder Error
+
+# --- The opt-out knob exists and is settable. The banner itself cannot be
+#     observed from a .test file at all -- stderr is not a tty here, which is
+#     precisely the guarantee that keeps this suite's expected output unchanged.
+statement ok
+SET datazoo_banner = false;
+
+statement ok
+SET datazoo_banner = true;


### PR DESCRIPTION
OAuth breaks against real IdP configurations we cannot reproduce here — Entra app roles, Google's string-typed numeric claims, Keycloak realms — so the users who hit a problem are the only ones who can tell us what it was. Two surfaces now point at the tracker.

Part of a fleet-wide rollout; implementation is the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule, so the wording is fixed in one place. Same pattern as [erpl-tunnel#2](https://github.com/DataZooDE/erpl-tunnel/pull/2) and erpl-adt#36.

## What changed

**Once-a-day banner on interactive load.** Prints only when stderr is a terminal, no CI marker is set, `DATAZOO_NO_BANNER` is unset, `SET datazoo_banner` is not false, and the `~/.duckdb` stamp is over a day old. Piped output, notebooks, CI and the test suite see **nothing** — which is why no existing expected output changes.

**Issue link on every error** raised by a registered function, via `DATAZOO_GUARD` at the 11 registration sites. Preserves the original `ExceptionType`; leaves `INTERRUPT`, `FATAL`, `OUT_OF_MEMORY` alone.

```
Invalid Input Error: quack_oauth_login: SECRET 'nope' not found
-> Unexpected? Please report it: https://github.com/DataZooDE/quack-oauth/issues
```

## Two things worth reviewing

**Errors DuckDB raises before dispatch are deliberately not annotated.** Binder, catalog and arity errors are not ours, and claiming them would send users to the wrong tracker. `quack_oauth_feedback.test` pins this.

**The banner include is placed unconditionally**, not after each file's last `#include`. In `check_authorization_function.cpp` and `diagnose.cpp` the latter would have landed the include inside `#ifndef EMSCRIPTEN` and broken the wasm configuration — the identical mistake broke erpl-tunnel's SSH-only and musl builds before I caught it.

## Verified

- Banner once interactively, silent on repeat, silent when piped
- Error footer present with the original diagnostic intact
- **168 assertions in 11 cases pass**, plus the new `quack_oauth_feedback.test` (5 assertions)
- `duckdb` submodule pin untouched (the dirty marker is the pre-existing configure-time fmt patch)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/quack-oauth/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788615112&installation_model_id=425457&pr_number=12&repository=DataZooDE%2Fquack-oauth&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fquack-oauth%2Fpull%2F12&signature=203804c4bd27259e8dc88c0bdbb69e2dad9799ccb68ca07574638836eedb6258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->